### PR TITLE
Use config file instead of env variables:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM rabbitmq:3.5.4-management
+
+ADD ./rabbitmq.config /etc/rabbitmq/rabbitmq.config

--- a/launch/heka-queue.yml
+++ b/launch/heka-queue.yml
@@ -1,11 +1,6 @@
 run:
   type: docker
-env:
-- RABBITMQ_ERLANG_COOKIE
-- RABBITMQ_DEFAULT_USER
-- RABBITMQ_DEFAULT_PASS
-- RABBITMQ_NODE_PORT
-- RABBITMQ_MANAGEMENT_LISTENER_PORT
+env: []
 resources:
   cpu: 2
 volumes:

--- a/rabbitmq.config
+++ b/rabbitmq.config
@@ -1,0 +1,12 @@
+[{rabbit,
+  [
+    {default_user, <<"clever">>},
+    {default_pass, <<"clever">>}
+  ]
+ },
+ {rabbitmq_management,
+  [{listener, [{port, 1567},
+               {ip, "0.0.0.0"}
+              ]}
+  ]}
+].


### PR DESCRIPTION
- It's not possible to set the management port via environment
  variables.  Furthermore, using env variables for config overwrites the
  existing config file, so you can't mix the two.